### PR TITLE
Add loading skeletons for media

### DIFF
--- a/src/components/globals/ImageWithLoader.tsx
+++ b/src/components/globals/ImageWithLoader.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import Image, { ImageProps } from "next/image";
+
+interface ImageWithLoaderProps extends ImageProps {
+  skipLoader?: boolean;
+}
+
+const SMALL_AREA = 150 * 150; // threshold for small images
+
+const ImageWithLoader: React.FC<ImageWithLoaderProps> = ({
+  skipLoader,
+  className = "",
+  ...props
+}) => {
+  const [loaded, setLoaded] = useState(false);
+  const area =
+    typeof props.width === "number" && typeof props.height === "number"
+      ? props.width * props.height
+      : Number(props.width) * Number(props.height);
+  const shouldSkip =
+    skipLoader || (area && area <= SMALL_AREA);
+
+  return (
+    <div
+      className="relative inline-block"
+      style={{ width: props.width, height: props.height }}
+    >
+      {!shouldSkip && !loaded && (
+        <div className="absolute inset-0 bg-neutral-300 animate-pulse rounded" />
+      )}
+      <Image
+        {...props}
+        className={
+          className + (shouldSkip || loaded ? "" : " opacity-0")
+        }
+        onLoadingComplete={() => setLoaded(true)}
+      />
+    </div>
+  );
+};
+
+export default ImageWithLoader;

--- a/src/components/globals/VideoWithLoader.tsx
+++ b/src/components/globals/VideoWithLoader.tsx
@@ -1,0 +1,44 @@
+import React, { useState, VideoHTMLAttributes } from "react";
+
+interface VideoWithLoaderProps extends VideoHTMLAttributes<HTMLVideoElement> {
+  skipLoader?: boolean;
+  width: number | string;
+  height: number | string;
+}
+
+const SMALL_AREA = 150 * 150;
+
+const VideoWithLoader: React.FC<VideoWithLoaderProps> = ({
+  skipLoader,
+  width,
+  height,
+  className = "",
+  onLoadedData,
+  ...props
+}) => {
+  const [loaded, setLoaded] = useState(false);
+  const area = Number(width) * Number(height);
+  const shouldSkip = skipLoader || (area && area <= SMALL_AREA);
+
+  const handleLoadedData = (e: React.SyntheticEvent<HTMLVideoElement, Event>) => {
+    setLoaded(true);
+    onLoadedData && onLoadedData(e);
+  };
+
+  return (
+    <div className="relative inline-block" style={{ width, height }}>
+      {!shouldSkip && !loaded && (
+        <div className="absolute inset-0 bg-neutral-300 animate-pulse rounded" />
+      )}
+      <video
+        width={width}
+        height={height}
+        onLoadedData={handleLoadedData}
+        className={className + (shouldSkip || loaded ? "" : " opacity-0")}
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default VideoWithLoader;

--- a/src/pages/aboutMe.tsx
+++ b/src/pages/aboutMe.tsx
@@ -5,7 +5,7 @@ import WorldMap from "@/components/WorldMap";
 import Header from "@/components/globals/header";
 import { faArrowDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import Image from "next/image";
+import ImageWithLoader from "@/components/globals/ImageWithLoader";
 import Link from "next/link";
 import { FaMailBulk } from "react-icons/fa";
 
@@ -96,7 +96,7 @@ export default function AboutMe() {
                   drive innovation, and build impactful solutions that deliver
                   exceptional user experiences.
                 </p>
-                <Image
+                <ImageWithLoader
                   src="/images/about/portrait.jpeg"
                   alt="Angus Blomley"
                   width={200}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,8 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import Button from "@/components/globals/Button";
-import Image from "next/image";
+import ImageWithLoader from "@/components/globals/ImageWithLoader";
+import VideoWithLoader from "@/components/globals/VideoWithLoader";
 
 interface DisplayLinkItemProps {
   href?: string;
@@ -275,7 +276,7 @@ function HomePage() {
                     Total Degree Credits: 360
                   </p>
                   <div className="mt-8">
-                    <Image
+                    <ImageWithLoader
                       width={300}
                       height={150}
                       id="ravensbourne-light"
@@ -283,7 +284,7 @@ function HomePage() {
                       alt="Ravensbourne University (Light Mode Logo)"
                       className="block"
                     />
-                    <Image
+                    <ImageWithLoader
                       width={300}
                       height={150}
                       id="ravensbourne-dark"
@@ -299,7 +300,7 @@ function HomePage() {
               variants={blockVariants}
               className="relative mb-12 flex items-center justify-center min-h-[340px] max-md:justify-start"
             >
-              <Image
+              <ImageWithLoader
                 id="graduation"
                 alt="graduation"
                 src="/images/index/graduation.svg"
@@ -336,7 +337,7 @@ function HomePage() {
                     <li>Computer Systems</li>
                   </ul>
                   <div className="mt-8">
-                    <Image
+                    <ImageWithLoader
                       width={150}
                       height={150}
                       id="belfastmet"
@@ -352,7 +353,7 @@ function HomePage() {
               variants={blockVariants}
               className="relative flex items-center justify-end min-h-[340px]"
             >
-              <Image
+              <ImageWithLoader
                 id="computer"
                 alt="Computer"
                 src="/images/index/computer.svg"
@@ -395,7 +396,7 @@ function HomePage() {
                     <li>Algorithms</li>
                   </ul>
                   <div className="mt-8">
-                    <Image
+                    <ImageWithLoader
                       width={220}
                       height={150}
                       id="codecademy"
@@ -417,7 +418,7 @@ function HomePage() {
               variants={blockVariants}
               className="relative mb-12 flex items-center justify-start min-h-[340px] max-md:justify-center"
             >
-              <Image
+              <ImageWithLoader
                 id="networking"
                 alt="networking graphic"
                 src="/images/index/networking.svg"
@@ -561,7 +562,7 @@ function HomePage() {
           <div className="absolute inset-0 bg-gradient-to-r from-theme-bg-dark to-transparent z-10 via-30% via-theme-bg-dark/0 opacity-0 max-md:via-theme-bg-dark/60"></div>
           <div className="absolute inset-0 bg-gradient-to-t from-theme-bg-dark to-transparent z-10 via-30% via-theme-bg-dark/50 opacity-100 max-md:via-theme-bg-dark/30"></div>
 
-          <Image
+          <ImageWithLoader
             alt="About background image"
             src="/images/index/back.jpg"
             layout="fill"
@@ -640,7 +641,7 @@ function HomePage() {
                       </div>
                     </div>
                     <div className="relative aspect-video overflow-hidden">
-                      <video
+                      <VideoWithLoader
                         title="Vocabo Chrome Extension Demo"
                         src="/videos/vocabo.mp4"
                         autoPlay
@@ -737,7 +738,7 @@ function HomePage() {
                         <div className="w-2 h-2 rounded-full bg-green-400"></div>
                       </div>
                     </div>
-                    <video
+                    <VideoWithLoader
                       title="PWG Mobile App Demo"
                       src="/videos/pwg_web.mp4"
                       autoPlay
@@ -779,7 +780,7 @@ function HomePage() {
                         <div className="w-2 h-2 rounded-full bg-green-400"></div>
                       </div>
                     </div>
-                    <Image
+                    <ImageWithLoader
                       id="openfern"
                       alt="Open Fern Studio Website"
                       src="/images/work/openfern.png"
@@ -892,7 +893,7 @@ function HomePage() {
               </div>
             </form>
           )}
-          <Image
+          <ImageWithLoader
             alt="contact"
             src="/images/index/contact.svg"
             width={550}

--- a/src/pages/work/beFirst.tsx
+++ b/src/pages/work/beFirst.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/no-unescaped-entities */
 import Header from "@/components/globals/header";
 import Footer from "@/components/globals/footer";
-import Image from "next/image";
+import ImageWithLoader from "@/components/globals/ImageWithLoader";
+import VideoWithLoader from "@/components/globals/VideoWithLoader";
 import ProjectNavigation from "@/components/work/ProjectNavigation";
 
 const BeFirst = () => {
@@ -84,7 +85,7 @@ const BeFirst = () => {
                 rel="noopener noreferrer"
               >
                 <div className="relative aspect-video">
-                  <video
+                  <VideoWithLoader
                     title="Advent Delights Project"
                     src="/videos/beFirst.mp4"
                     autoPlay
@@ -317,14 +318,14 @@ const BeFirst = () => {
                 </div>
               </div>
               <div className="flex row h-16 flex-wrap">
-                <Image
+                <ImageWithLoader
                   src="/images/icons/premiere-pro.webp"
                   alt="Adobe Premiere Pro"
                   width={50}
                   height={50}
                   className="my-2 py-2"
                 />
-                <Image
+                <ImageWithLoader
                   src="/images/icons/photoshop.webp"
                   alt="Adobe Photoshop"
                   width={50}

--- a/src/pages/work/celestialObjectTracker.tsx
+++ b/src/pages/work/celestialObjectTracker.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Header from "@/components/globals/header";
 import Footer from "@/components/globals/footer";
-import Image from "next/image";
+import ImageWithLoader from "@/components/globals/ImageWithLoader";
 import ProjectNavigation from "@/components/work/ProjectNavigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -75,7 +75,7 @@ const CelestialObjectTracker = () => {
                   transition={{ duration: 0.8, ease: [0.4, 0, 0.2, 1] }}
                   className="absolute inset-0 w-full h-full"
                 >
-                  <Image
+                  <ImageWithLoader
                     alt="Celestial Object Tracker Project Image Carousel"
                     src={images[currentIndex]}
                     fill
@@ -171,35 +171,35 @@ const CelestialObjectTracker = () => {
                   Technologies Used
                 </h3>
                 <div className="flex flex-wrap gap-4 items-center">
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/python.webp"
                     alt="Python"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/raspberrypi.webp"
                     alt="Raspberry Pi"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/arduino.webp"
                     alt="Arduino"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/fusion360.png"
                     alt="Fusion 360"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/github.webp"
                     alt="GitHub"
                     width={40}

--- a/src/pages/work/japaneseHostFamily.tsx
+++ b/src/pages/work/japaneseHostFamily.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Image from "next/image";
+import ImageWithLoader from "@/components/globals/ImageWithLoader";
 import Header from "@/components/globals/header";
 import Footer from "@/components/globals/footer";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -40,7 +40,7 @@ const JapaneseHostFamilyPage: React.FC = () => {
         </div>
 
         <div className="mb-8 max-w-4xl mx-auto">
-          <Image
+          <ImageWithLoader
             src="/images/japanese-host-family/japanese-host-family.png"
             alt="Japanese Host Family Platform Screenshot"
             width={1200}
@@ -140,35 +140,35 @@ const JapaneseHostFamilyPage: React.FC = () => {
           <div className="mt-6">
             <h3 className="text-xl font-semibold mb-2">Technologies Used</h3>
             <div className="flex flex-wrap gap-4 items-center">
-              <Image
+              <ImageWithLoader
                 src="/images/icons/react.webp"
                 alt="React"
                 width={40}
                 height={40}
                 style={{ objectFit: "contain" }}
               />
-              <Image
+              <ImageWithLoader
                 src="/images/icons/typescript.png"
                 alt="TypeScript"
                 width={40}
                 height={40}
                 style={{ objectFit: "contain" }}
               />
-              <Image
+              <ImageWithLoader
                 src="/images/icons/tailwind.webp"
                 alt="Tailwind CSS"
                 width={40}
                 height={40}
                 style={{ objectFit: "contain" }}
               />
-              <Image
+              <ImageWithLoader
                 src="/images/icons/supabase.jpeg"
                 alt="Supabase"
                 width={40}
                 height={40}
                 style={{ objectFit: "contain", borderRadius: "0.5rem" }}
               />
-              <Image
+              <ImageWithLoader
                 src="/images/icons/github.webp"
                 alt="GitHub"
                 width={40}

--- a/src/pages/work/meetly.tsx
+++ b/src/pages/work/meetly.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/no-unescaped-entities */
 import Header from "@/components/globals/header";
 import Footer from "@/components/globals/footer";
-import Image from "next/image";
+import ImageWithLoader from "@/components/globals/ImageWithLoader";
+import VideoWithLoader from "@/components/globals/VideoWithLoader";
 import ProjectNavigation from "@/components/work/ProjectNavigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -41,7 +42,7 @@ const Meetly = () => {
           </div>
 
           <div className="mb-8 max-w-4xl mx-auto rounded-lg overflow-hidden shadow-lg border relative aspect-video">
-            <video
+            <VideoWithLoader
               src="/videos/meetly.mp4"
               autoPlay
               muted
@@ -127,42 +128,42 @@ const Meetly = () => {
                   Technologies Used
                 </h3>
                 <div className="flex flex-wrap gap-4 items-center">
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/next.webp"
                     alt="Next.js"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/react.webp"
                     alt="React"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/tailwind.webp"
                     alt="Tailwind CSS"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/maps2.png"
                     alt="Google Maps API"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/axios.webp"
                     alt="Axios"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/github.webp"
                     alt="GitHub"
                     width={40}

--- a/src/pages/work/openfern.tsx
+++ b/src/pages/work/openfern.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unescaped-entities */
 import Header from "@/components/globals/header";
 import Footer from "@/components/globals/footer";
-import Image from "next/image";
+import ImageWithLoader from "@/components/globals/ImageWithLoader";
 import ProjectNavigation from "@/components/work/ProjectNavigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
@@ -41,7 +41,7 @@ const OpenFern = () => {
           </div>
 
           <div className="mb-8 max-w-4xl mx-auto">
-            <Image
+            <ImageWithLoader
               src="/images/work/openfern.png"
               alt="Open Fern Studio Website Screenshot"
               width={1200} // Adjusted for consistency
@@ -108,28 +108,28 @@ const OpenFern = () => {
                   Technologies Used
                 </h3>
                 <div className="flex flex-wrap gap-4 items-center">
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/next.webp"
                     alt="Next.js"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/react.webp"
                     alt="TypeScript"
                     width={35}
                     height={35}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/tailwind.webp"
                     alt="Tailwind CSS"
                     width={40}
                     height={40}
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/github.webp"
                     alt="GitHub"
                     width={40}

--- a/src/pages/work/pwg.tsx
+++ b/src/pages/work/pwg.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/no-unescaped-entities */
 import Header from "@/components/globals/header";
 import Footer from "@/components/globals/footer";
-import Image from "next/image";
+import ImageWithLoader from "@/components/globals/ImageWithLoader";
+import VideoWithLoader from "@/components/globals/VideoWithLoader";
 import ProjectNavigation from "@/components/work/ProjectNavigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -31,7 +32,7 @@ const PWG = () => {
           {/* First Video */}
           <div className="mb-8 max-w-4xl mx-auto">
             <div className="rounded-lg overflow-hidden shadow-lg relative">
-              <video
+              <VideoWithLoader
                 src="/videos/pwg_web.mp4"
                 autoPlay
                 muted
@@ -61,7 +62,7 @@ const PWG = () => {
             {/* Second Video - Moved and Resized */}
             <div className="my-8 max-w-lg mx-auto">
               <div className="rounded-lg overflow-hidden shadow-lg relative">
-                <video
+                <VideoWithLoader
                   src="/videos/pwg_tablet.webm"
                   autoPlay
                   muted
@@ -142,7 +143,7 @@ const PWG = () => {
                   Technologies Used
                 </h3>
                 <div className="flex justify-start items-center flex-wrap">
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/react.webp"
                     alt="React Native"
                     width={50}
@@ -150,7 +151,7 @@ const PWG = () => {
                     className="m-2"
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/js.webp"
                     alt="JavaScript"
                     width={50}
@@ -158,7 +159,7 @@ const PWG = () => {
                     className="m-2"
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/tailwind.webp"
                     alt="Tailwind CSS / NativeWind"
                     width={50}
@@ -166,7 +167,7 @@ const PWG = () => {
                     className="m-2 py-1"
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/expoGo.svg"
                     alt="Expo"
                     width={50}
@@ -174,7 +175,7 @@ const PWG = () => {
                     className="m-2"
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/github.webp"
                     alt="GitHub"
                     width={50}

--- a/src/pages/work/stringBox.tsx
+++ b/src/pages/work/stringBox.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import Header from "@/components/globals/header";
 import Footer from "@/components/globals/footer";
-import Image from "next/image";
+import ImageWithLoader from "@/components/globals/ImageWithLoader";
+import VideoWithLoader from "@/components/globals/VideoWithLoader";
 import { useDarkMode } from "@/contexts/darkModeContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -44,7 +45,7 @@ const StringBox = () => {
 
         {/* Main Video */}
         <div className="mb-8 max-w-4xl mx-auto rounded-lg overflow-hidden shadow-lg relative aspect-video">
-          <video
+          <VideoWithLoader
             src="/videos/stringBoxWeb.mp4"
             autoPlay
             muted
@@ -108,35 +109,35 @@ const StringBox = () => {
           <div className="mt-6">
             <h3 className="text-xl font-semibold mb-2">Technologies Used</h3>
             <div className="flex flex-wrap gap-4 items-center mb-6">
-              <Image
+              <ImageWithLoader
                 src="/images/icons/next.webp"
                 alt="Next.js"
                 width={40}
                 height={40}
                 style={{ objectFit: "contain" }}
               />
-              <Image
+              <ImageWithLoader
                 src="/images/icons/react.webp"
                 alt="React"
                 width={40}
                 height={40}
                 style={{ objectFit: "contain" }}
               />
-              <Image
+              <ImageWithLoader
                 src="/images/icons/js.webp"
                 alt="JavaScript"
                 width={40}
                 height={40}
                 style={{ objectFit: "contain" }}
               />
-              <Image
+              <ImageWithLoader
                 src="/images/icons/tailwind.webp"
                 alt="Tailwind CSS"
                 width={40}
                 height={40}
                 style={{ objectFit: "contain" }}
               />
-              <Image
+              <ImageWithLoader
                 src="/images/icons/github.webp"
                 alt="GitHub"
                 width={40}

--- a/src/pages/work/vocabo.tsx
+++ b/src/pages/work/vocabo.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/no-unescaped-entities */
 import Header from "@/components/globals/header";
 import Footer from "@/components/globals/footer";
-import Image from "next/image";
+import ImageWithLoader from "@/components/globals/ImageWithLoader";
+import VideoWithLoader from "@/components/globals/VideoWithLoader";
 import ProjectNavigation from "@/components/work/ProjectNavigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChrome } from "@fortawesome/free-brands-svg-icons";
@@ -41,7 +42,7 @@ const Vocabo = () => {
             className="hidden lg:block mx-auto mb-8 rounded-lg shadow-xl overflow-hidden"
             style={{ width: 1080, height: 561 }}
           >
-            <video
+            <VideoWithLoader
               title="Vocabo Chrome Extension Demo"
               src="/videos/vocabo.mp4"
               width={1080}
@@ -63,7 +64,7 @@ const Vocabo = () => {
 
           {/* Mobile/Tablet (below lg): responsive styling */}
           <div className="block lg:hidden mx-auto mb-8 rounded-lg shadow-xl overflow-hidden w-full max-w-3xl aspect-video bg-black">
-            <video
+            <VideoWithLoader
               title="Vocabo Chrome Extension Demo"
               src="/videos/vocabo.mp4"
               autoPlay
@@ -141,7 +142,7 @@ const Vocabo = () => {
                   Technologies Used
                 </h3>
                 <div className="flex flex-wrap gap-2 items-center">
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/react.webp"
                     alt="React"
                     width={40}
@@ -149,7 +150,7 @@ const Vocabo = () => {
                     className="m-2"
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/js.webp"
                     alt="JavaScript"
                     width={40}
@@ -157,7 +158,7 @@ const Vocabo = () => {
                     className="m-2"
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/tailwind.webp"
                     alt="Tailwind CSS"
                     width={40}
@@ -165,7 +166,7 @@ const Vocabo = () => {
                     className="m-2 py-1"
                     style={{ objectFit: "contain" }}
                   />
-                  <Image
+                  <ImageWithLoader
                     src="/images/icons/github.webp"
                     alt="GitHub"
                     width={40}


### PR DESCRIPTION
## Summary
- create `ImageWithLoader` and `VideoWithLoader` to show a subtle loading state
- replace all `next/image` instances with `ImageWithLoader`
- wrap videos with `VideoWithLoader`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840024643c88332877ea30863fa98ce